### PR TITLE
Add Robert as cluster administrator

### DIFF
--- a/cluster-resources/rbac/group-incubator-admins.yaml
+++ b/cluster-resources/rbac/group-incubator-admins.yaml
@@ -26,3 +26,4 @@ users:
   - marcschmidlin
   - makrelas
   - koenigle
+  - robert-groensfeld


### PR DESCRIPTION
I need access to the ArgoCD namespace to test notifications.

robert.groensfeld@baloise.ch